### PR TITLE
Update terraform to 0.8.6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,10 +83,10 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.5.1/bin/li
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 
-echo "================= Adding terraform ==================="
-curl -LO https://releases.hashicorp.com/terraform/0.8.5/terraform_0.8.5_linux_amd64.zip
-unzip terraform_0.8.5_linux_amd64.zip -d /usr/local/bin/terraform
-echo 'export PATH=$PATH:/usr/local/bin/terraform' >> /root/.bashrc
+echo "================= Adding terraform 0.8.6 ==================="
+curl -LO https://releases.hashicorp.com/terraform/0.8.6/terraform_0.8.6_linux_amd64.zip
+unzip terraform_0.8.6_linux_amd64.zip -d /usr/local/bin/terraform
+# terraform also requires an alteration of PATH; this is done in the runCLI script
 
 echo "================= Adding utilities ==================="
 apt-get install -y gettext \


### PR DESCRIPTION
https://github.com/Shippable/microbase/issues/38

Updates terraform to the latest version
Removes the PATH alteration (this has to happen in the runCLI scripts)

Tested by building the image; the resulting version of terraform was correct.