### PR TITLE
switch to 4.8.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,9 @@ hash -r
 echo "================== Installing python requirements ====="
 pip install -r /home/shippable/appBase/requirements.txt
 
-apt-get install -y nodejs
+wget https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x64.tar.xz
+tar -xvf node-v4.8.0-linux-x64.tar.xz
+cp -Rvf node-v4.8.0-linux-x64/{bin,include,lib,share} /usr/local
 npm install -g forever@0.14.2 grunt grunt-cli
 
 echo "================= Cleaning package lists ==================="


### PR DESCRIPTION
#50

this updates the install script.  instead of relying on apt-get, we will download a binary for the specific version of node that we want, then copy it to /usr/local.  when running this image or images based on it, the result of `node -v` will be `4.8.0`